### PR TITLE
chore,docs: update package.json and docs to support OpenUPM

### DIFF
--- a/docs~/docs/getting-started/installation.md
+++ b/docs~/docs/getting-started/installation.md
@@ -33,6 +33,41 @@ It also makes updating DressingTools easier for users.
 
     [![Installation VCC Teaser](/img/teaser-1.PNG)](/img/teaser-1.PNG)
 
+### Via OpenUPM
+
+:::info
+[OpenUPM](https://openupm.com) is a package registry for open-source Unity packages. It can handle package updates and dependencies properly compared to UPM Git URL.
+
+It is recommended to use OpenUPM for installation if you are not using VCC. Especially for users who are not using DressingTools for VRChat.
+:::
+
+You can install DressingTools via OpenUPM by following the instructions below.
+
+#### A. Install via OpenUPM command-line interface (CLI)
+1. If you haven't already, install the OpenUPM CLI by following the instructions on the [OpenUPM website](https://openupm.com/docs/getting-started-cli.html).
+
+2. Run the following command in your project directory to install DressingTools, its dependencies will also be installed automatically:
+```shell
+openupm add com.chocopoi.vrc.dressingtools
+```
+
+#### B. Install manually via Unity Package Manager (UPM)
+Please follow the instrustions:
+1. Open **Edit/Project Settings/Package Manager**
+2. Add the following scoped registry:
+    - Name: `package.openupm.com`
+    - URL: `https://package.openupm.com`
+    - Scopes:
+        - `com.chocopoi.vrc.avatarlib`
+        - `com.chocopoi.vrc.dressingframework`
+        - `com.chocopoi.vrc.dressingtools`
+3. Click `Save` or `Apply`
+4. Open **Window/Package Manager**
+5. Select `Add package by name...` or `Add package from git URL...`
+6. Paste `com.chocopoi.vrc.dressingtools` into `Name`
+7. Paste your desired version ([listed here](https://openupm.com/packages/com.chocopoi.vrc.dressingtools/?subPage=versions)) into `Version`, or leave it empty to get the latest version.
+8. Click `Add`
+
 ### Via .unitypackage
 
 :::info
@@ -82,7 +117,7 @@ Unity does not handle updates and dependencies properly for UPM Git URLs. Make s
 
     [![Installation UPM Git Add from git URL](/img/installation-upmgit-install-from-git.PNG)](/img/installation-upmgit-install-from-git.PNG)
 
-3. Add the following packages and make sure the required versions match the version of DressingTools that you are installing. Change the version after the `#` to your desired one.
+3. Add the following packages from top to bottom, make sure the required versions match the version of DressingTools that you are installing. Change the version after the `#` to your desired one.
 
     - AvatarLib
         - `https://github.com/poi-vrc/AvatarLib.git#1.0.2`

--- a/docs~/i18n/zh-Hant/docusaurus-plugin-content-docs/current/getting-started/installation.md
+++ b/docs~/i18n/zh-Hant/docusaurus-plugin-content-docs/current/getting-started/installation.md
@@ -32,6 +32,41 @@ DressingTools 是一個 **獨立的 Unity UPM 套件** 和 **不需要安裝任�
 
    [![安裝 VCC 預告片](/img/teaser-1.PNG)](/img/teaser-1.PNG)
 
+### 透過 OpenUPM
+
+:::info
+[OpenUPM](https://openupm.com) 是一個供開源 Unity 套件的套件庫。相較於 UPM Git URL，它可以更加妥善的處理套件更新和相依性。
+
+如果您不使用 VCC，建議使用 OpenUPM 進行安裝。特別是對於不使用 DressingTools 用於 VRChat 的用戶。
+:::
+
+您可以按照以下說明透過 OpenUPM 安裝 DressingTools。
+
+#### A. 透過 OpenUPM 命令列介面 (CLI)
+1. 如果您尚未安裝，請按照 [OpenUPM 網站](https://openupm.com/docs/getting-started-cli.html) 上的說明安裝 OpenUPM CLI。
+
+2. 在您的專案目錄中執行以下命令以安裝 DressingTools，它的相依套件也將自動安裝：
+```shell
+openupm add com.chocopoi.vrc.dressingtools
+```
+
+#### B. 透過 Unity 套件管理器 (UPM) 手動安裝
+請按照以下指示：
+1. 開啟 **Edit/Project Settings/Package Manager**
+2. 新增以下 scoped registry:
+    - Name: `package.openupm.com`
+    - URL: `https://package.openupm.com`
+    - Scopes:
+        - `com.chocopoi.vrc.avatarlib`
+        - `com.chocopoi.vrc.dressingframework`
+        - `com.chocopoi.vrc.dressingtools`
+3. 點擊 `Save` 或是 `Apply`
+4. 開啟 **Window/Package Manager**
+5. 選擇 `Add package by name...` 或 `Add package from git URL...`
+6. 將 `com.chocopoi.vrc.dressingtools` 貼上到 `Name`
+7. 參考[版本清單](https://openupm.com/packages/com.chocopoi.vrc.dressingtools/?subPage=versions)，貼上您想要安裝的版本到 `Version`，或是留空以取得最新版本。
+8. 點擊 `Add`
+
 ### 透過 .unitypackage
 
 :::info
@@ -79,7 +114,7 @@ Unity 不會處理 UPM Git URL 的更新和依賴項。確保安裝正確版本�
 
    [![安裝 UPM Git](/img/installation-upmgit-install-from-git.PNG)](/img/installation-upmgit-install-from-git.PNG)
 
-3. 新增以下套件並確保所需版本與您正在安裝的 DressingTools 版本相符。將`#`後面的版本變更為您想要的版本。
+3. 從上到下新增以下套件，並確保所需版本與您正在安裝的 DressingTools 版本相符。將`#`後面的版本變更為您想要的版本。
 
     - AvatarLib
         - `https://github.com/poi-vrc/AvatarLib.git#1.0.2`

--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
     },
     "url": "https://github.com/poi-vrc/DressingTools",
     "dependencies": {
-        "com.unity.nuget.newtonsoft-json": "2.0.2"
+        "com.unity.nuget.newtonsoft-json": "2.0.2",
+        "com.chocopoi.vrc.avatarlib": "1.1.0",
+        "com.chocopoi.vrc.dressingframework": "2.1.1"
     },
     "vpmDependencies": {
         "com.vrchat.avatars": ">=3.2.0",


### PR DESCRIPTION
Add OpenUPM support for DressingTools.

---

[OpenUPM](https://openupm.com) is a package registry for open-source Unity packages. It can handle package updates and dependencies properly compared to UPM Git URL.

Personally, I recommended to use OpenUPM for installation if user is not using VCC. Especially for users who are not using DressingTools for VRChat.

Users can benefit from automatic package updates and dependencies resolving that OpenUPM (Unity scoped registry) provides.

---

In order to support OpenUPM, DressingTools' dependencies `AvatarLib` and `DressingFramework` have been added to `dependencies` property in `package.json`.

Hence, in the future user will have to install `AvatarLib` and `DressingFramework` first, then `DressingTools`. Otherwise, Unity will refuse to install DressingTools because its dependencies are not fulfilled.

---

Both English and Chinese (Traditional) documentations are updated.
For other languages, because I am not fluent in those languages, I am unable to help with those documentation.

---
OpenUPM page for `DressingTools` and its dependencies:

DressingTools:
https://openupm.com/packages/com.chocopoi.vrc.dressingtools/

DressingFramework:
https://openupm.com/packages/com.chocopoi.vrc.dressingframework/

AvatarLib:
https://openupm.com/packages/com.chocopoi.vrc.avatarlib/